### PR TITLE
Bug fix for comparison missing the array index which leads to fatal I2C read error -1010

### DIFF
--- a/klef-piano.py
+++ b/klef-piano.py
@@ -40,7 +40,7 @@ class KitronikPiano:
             reading = True
             while reading:
                 readBuff = i2c.read(self.CHIP_ADDRESS, 1, False)
-                if (readBuff == 0x11):
+                if (readBuff[0] == 0x11):
                     reading = False
             
             # Change sensitivity (burst length) of keys 0-14 to keySensitivity (default is 8)


### PR DESCRIPTION
Two changes:

- bug fix for comparison which was broken due to lack of array index (Python's `==` operator will try and compared anything with anything and pylint has minimal reporting capability here)
- tacked a newline on the last line as it was missing it

The bug completes the fix in #2. Without the fix this will be seen after 5-25 seconds and the program does not work.

```
Traceback (most recent call last):
  File "__main__", line 127, in <module>
  File "__main__", line 42, in __init__
OSError: I2C read error -1010
```
